### PR TITLE
Fix missing argument when calling setters from MOI

### DIFF
--- a/src/MOI_wrapper/MOI_wrapper.jl
+++ b/src/MOI_wrapper/MOI_wrapper.jl
@@ -98,7 +98,15 @@ function MOI.set(model::Optimizer, param::MOI.RawParameter, value)
         push!(model.options_set, key)
         CLP_OPTION_MAP[key][2](model.inner, value)
     elseif haskey(SOLVE_OPTION_MAP, key)
-        SOLVE_OPTION_MAP[key][2](model.solver_options, value)
+        # Setters for `SolveType` and `PresolveType` are handled separately,
+        # as they have a third `extraInfo` argument
+        if key == :SolveType
+            ClpSolve_setSolveType(model.solver_options, value, -1)
+        elseif key == :PresolveType
+            ClpSolve_setPresolveType(model.solver_options, value, -1)
+        else
+            SOLVE_OPTION_MAP[key][2](model.solver_options, value)
+        end
     else
         throw(MOI.UnsupportedAttribute(param))
     end

--- a/src/MOI_wrapper/MOI_wrapper.jl
+++ b/src/MOI_wrapper/MOI_wrapper.jl
@@ -95,13 +95,13 @@ MOI.supports(::Optimizer, param::MOI.RawParameter) = true
 function MOI.set(model::Optimizer, param::MOI.RawParameter, value)
     key = Symbol(param.name)
     
-    # Setters for `SolveType` and `PresolveType` are handled separately,
-    # as they have a third `extraInfo` argument
+    # Setters for `SolveType`, `PresolveType` and `InfeasibleReturn`
+    # are handled separately, see https://github.com/jump-dev/Clp.jl/issues/91
     if haskey(CLP_OPTION_MAP, key)
         push!(model.options_set, key)
         CLP_OPTION_MAP[key][2](model.inner, value)
     elseif key == :SolveType
-            ClpSolve_setSolveType(model.solver_options, value, -1)
+        ClpSolve_setSolveType(model.solver_options, value, -1)
     elseif key == :PresolveType
         ClpSolve_setPresolveType(model.solver_options, value, -1)
     elseif key == :InfeasibleReturn

--- a/src/MOI_wrapper/MOI_wrapper.jl
+++ b/src/MOI_wrapper/MOI_wrapper.jl
@@ -94,19 +94,18 @@ MOI.supports(::Optimizer, param::MOI.RawParameter) = true
 
 function MOI.set(model::Optimizer, param::MOI.RawParameter, value)
     key = Symbol(param.name)
+    
+    # Setters for `SolveType` and `PresolveType` are handled separately,
+    # as they have a third `extraInfo` argument
     if haskey(CLP_OPTION_MAP, key)
         push!(model.options_set, key)
         CLP_OPTION_MAP[key][2](model.inner, value)
-    elseif haskey(SOLVE_OPTION_MAP, key)
-        # Setters for `SolveType` and `PresolveType` are handled separately,
-        # as they have a third `extraInfo` argument
-        if key == :SolveType
+    elseif key == :SolveType
             ClpSolve_setSolveType(model.solver_options, value, -1)
-        elseif key == :PresolveType
-            ClpSolve_setPresolveType(model.solver_options, value, -1)
-        else
-            SOLVE_OPTION_MAP[key][2](model.solver_options, value)
-        end
+    elseif key == :PresolveType
+        ClpSolve_setPresolveType(model.solver_options, value, -1)
+    elseif key == :InfeasibleReturn
+        ClpSolve_setInfeasibleReturn(model.solver_options, value)
     else
         throw(MOI.UnsupportedAttribute(param))
     end

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -97,4 +97,18 @@ end
     MOI.set(model, MOI.RawParameter(:LogLevel), 2)
     @test MOI.get(model, MOI.RawParameter("LogLevel")) == 2
     @test MOI.get(model, MOI.RawParameter(:LogLevel)) == 2
+
+    MOI.set(model, MOI.RawParameter("SolveType"), 1)
+    @test MOI.get(model, MOI.RawParameter("SolveType")) == 1
+    @test MOI.get(model, MOI.RawParameter(:SolveType)) == 1
+    MOI.set(model, MOI.RawParameter("SolveType"), 4)
+    @test MOI.get(model, MOI.RawParameter("SolveType")) == 4
+    @test MOI.get(model, MOI.RawParameter(:SolveType)) == 4
+
+    MOI.set(model, MOI.RawParameter("PresolveType"), 1)
+    @test MOI.get(model, MOI.RawParameter("PresolveType")) == 1
+    @test MOI.get(model, MOI.RawParameter(:PresolveType)) == 1
+    MOI.set(model, MOI.RawParameter("PresolveType"), 0)
+    @test MOI.get(model, MOI.RawParameter("PresolveType")) == 0
+    @test MOI.get(model, MOI.RawParameter(:PresolveType)) == 0
 end


### PR DESCRIPTION
Fixes #91.

According to the [Clp C Interface](https://github.com/coin-or/Clp/blob/a9bd29ba44d0543da31adf73b0603886d312e457/src/Clp_C_Interface.h#L488-L506), setting `extraInfo = -1` results in default behavior.

I can see 3 ways of fixing this:
1. Add a default value to `ClpSolve_setSolveType` as follows:
    ```julia
    ClpSolve_setSolveType(arg1, method, extraInfo=Cint(-1))
    ```
    Pro: very short. Con: that file is generated automatically, so we probably don't want to modify it

2. (the one implemented here): extend the two setters to add the default value
   Pro: fixed the bug. Con: extends a function of the C API.

3. "hack" the `SOLVE_OPTION_MAP` dict as follows:
   ```julia
    :SolveType => (ClpSolve_getSolveType, (arg1, method) -> ClpSolve_setSolveType(arg1, method, -1))
    ```
    Pro: compact. Con: Not great for error messages.