### PR TITLE
Performance improvements

### DIFF
--- a/bench/runbench.jl
+++ b/bench/runbench.jl
@@ -13,14 +13,6 @@ struct RadomLP
     dens::Float64
 end
 
-time_limit_sec=Inf
-model = MOI.Bridges.full_bridge_optimizer(MOI.Utilities.CachingOptimizer(
-    MOI.Utilities.UniversalFallback(MOI.Utilities.Model{Float64}()),
-    Clp.Optimizer()), Float64)
-if isfinite(time_limit_sec)
-    MOI.set(model, MOI.TimeLimitSec(), time_limit_sec)
-end
-
 function generate_moi_problem(model, At, b, c;
     var_bounds = false, scalar = true)
     cols, rows = size(At)
@@ -153,14 +145,4 @@ function solve_clp(seed, data; time_limit_sec=Inf)
 
 end
 
-# function solve_scs(data::PMedianData)
-#     model = MOI.Bridges.full_bridge_optimizer(MOI.Utilities.CachingOptimizer(
-#         MOI.Utilities.UniversalFallback(MOI.Utilities.Model{Float64}()),
-#         SCS.Optimizer()), Float64)
-#     @time x, y = generate_moi_problem(model, data)
-#     @time MOI.optimize!(model)
-#     @show MOI.get(model, MOI.ObjectiveValue())
-# end
-
 solve_clp(10, RadomLP(10000, 20000, 0.01); time_limit_sec=5)
-# solve_scs(data)

--- a/bench/runbench.jl
+++ b/bench/runbench.jl
@@ -1,0 +1,166 @@
+using SparseArrays
+using LinearAlgebra
+using Random
+using Clp
+using MathOptInterface
+const MOI = MathOptInterface
+
+using TimerOutputs
+
+struct RadomLP
+    rows::Int
+    cols::Int
+    dens::Float64
+end
+
+time_limit_sec=Inf
+model = MOI.Bridges.full_bridge_optimizer(MOI.Utilities.CachingOptimizer(
+    MOI.Utilities.UniversalFallback(MOI.Utilities.Model{Float64}()),
+    Clp.Optimizer()), Float64)
+if isfinite(time_limit_sec)
+    MOI.set(model, MOI.TimeLimitSec(), time_limit_sec)
+end
+
+function generate_moi_problem(model, At, b, c;
+    var_bounds = false, scalar = true)
+    cols, rows = size(At)
+    x = MOI.add_variables(model, cols)
+    A_cols = rowvals(At)
+    A_vals = nonzeros(At)
+    if var_bounds
+        for col in 1:cols
+            MOI.add_constraint(model, MOI.SingleVariable(x[col]),
+                MOI.LessThan(10.0))
+            MOI.add_constraint(model, MOI.SingleVariable(x[col]),
+                MOI.GreaterThan(-10.0))
+        end
+    end
+    if scalar
+        for row in 1:rows
+            MOI.add_constraint(model, MOI.ScalarAffineFunction(
+                [MOI.ScalarAffineTerm(A_vals[i], x[A_cols[i]]) for i in nzrange(At, row)], 0.0),
+                MOI.LessThan(b[row]))
+        end
+    else
+        for row in 1:rows
+            MOI.add_constraint(model, MOI.VectorAffineFunction(
+                [MOI.VectorAffineTerm(1, 
+                    MOI.ScalarAffineTerm(A_vals[i], x[A_cols[i]])
+                ) for i in nzrange(At, row)], [-b[row]]),
+                MOI.Nonpositives(1))
+        end
+    end
+    objective = MOI.ScalarAffineFunction(
+        [MOI.ScalarAffineTerm(c[i], x[i]) for i in findall(!iszero, c)],
+            0.0)
+    MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), objective)
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+    return x
+end
+
+function random_data(seed, data)
+
+    rows = data.rows
+    cols = data.cols
+    density = data.dens
+
+    p_neg_element = 0.0 # 0.25
+
+    rng = Random.MersenneTwister(seed)
+
+    f_A(r, n) = ifelse.(rand(r, n) .> p_neg_element, 1, -1) .* (15 .+ 30 .* rand(r, n))
+
+    At = sprand(rng, cols, rows, density, f_A)
+    b = 50 * rand(rng, rows)
+
+    # not using signs now
+    sign = ifelse.(rand(rng, rows) .> 0.2, 'L', 'G')
+
+    f_c(r, n) = 20 .* 2 .* (rand(r, n) .- 0.5)
+    c = sprand(rng, cols, 0.5, f_c)
+
+    return At, b, c
+end
+
+function bridged_cache_and_solver()
+    model = MOI.Bridges.full_bridge_optimizer(MOI.Utilities.CachingOptimizer(
+        MOI.Utilities.UniversalFallback(MOI.Utilities.Model{Float64}()),
+        MOI.Utilities.MANUAL), Float64)
+    clp = Clp.Optimizer()
+    MOI.set(clp, MOI.Silent(), true)
+    return model, clp
+end
+function cache_and_solver()
+    model = MOI.Utilities.CachingOptimizer(
+        MOI.Utilities.UniversalFallback(MOI.Utilities.Model{Float64}()),
+        MOI.Utilities.MANUAL)
+    clp = Clp.Optimizer()
+    MOI.set(clp, MOI.Silent(), true)
+    return model, clp
+end
+function bridged_cached_solver()
+    model = MOI.Bridges.full_bridge_optimizer(MOI.Utilities.CachingOptimizer(
+        MOI.Utilities.UniversalFallback(MOI.Utilities.Model{Float64}()),
+        Clp.Optimizer()), Float64)
+    MOI.set(model, MOI.Silent(), true)
+    return model
+end
+function cached_solver()
+    model = MOI.Utilities.CachingOptimizer(
+        MOI.Utilities.UniversalFallback(MOI.Utilities.Model{Float64}()),
+        Clp.Optimizer())
+    MOI.set(model, MOI.Silent(), true)
+    return model
+end
+
+function time_build_and_solve(to_build, to_solve, At, b, c, scalar = true)
+    @timeit "build" x = generate_moi_problem(to_build, At, b, c, scalar = scalar)
+    if to_build !== to_solve
+        @timeit "copy" MOI.copy_to(to_solve, to_build, copy_names = false)
+    end
+    @time @timeit "opt" MOI.optimize!(to_solve)
+    MOI.get(to_solve, MOI.ObjectiveValue())
+    val = MOI.get(to_solve, MOI.SolveTime())
+    println(val)
+end
+
+function solve_clp(seed, data; time_limit_sec=Inf)
+
+    reset_timer!()
+
+    for i in 1:seed
+
+        @timeit "data"  At, b, c = random_data(i, data)
+
+        bridged_cache, pure_solver = bridged_cache_and_solver()
+        @timeit "bc + s" time_build_and_solve(bridged_cache, pure_solver, At, b, c)
+
+        cache, pure_solver2 = cache_and_solver()
+        @timeit "c + s" time_build_and_solve(cache, pure_solver2, At, b, c)
+
+        full_solver = bridged_cached_solver()
+        @timeit "bcs" time_build_and_solve(full_solver, full_solver, At, b, c)
+
+        full_solver = bridged_cached_solver()
+        @timeit "bcs + v" time_build_and_solve(full_solver, full_solver, At, b, c, false)
+
+        cache_solver = cached_solver()
+        @timeit "cs" time_build_and_solve(cache_solver, cache_solver, At, b, c)
+
+    end
+
+    print_timer()
+
+end
+
+# function solve_scs(data::PMedianData)
+#     model = MOI.Bridges.full_bridge_optimizer(MOI.Utilities.CachingOptimizer(
+#         MOI.Utilities.UniversalFallback(MOI.Utilities.Model{Float64}()),
+#         SCS.Optimizer()), Float64)
+#     @time x, y = generate_moi_problem(model, data)
+#     @time MOI.optimize!(model)
+#     @show MOI.get(model, MOI.ObjectiveValue())
+# end
+
+solve_clp(10, RadomLP(10000, 20000, 0.01); time_limit_sec=5)
+# solve_scs(data)

--- a/bench/runbench.jl
+++ b/bench/runbench.jl
@@ -7,7 +7,7 @@ const MOI = MathOptInterface
 
 using TimerOutputs
 
-struct RadomLP
+struct RandomLP
     rows::Int
     cols::Int
     dens::Float64
@@ -145,4 +145,4 @@ function solve_clp(seed, data; time_limit_sec=Inf)
 
 end
 
-solve_clp(10, RadomLP(10000, 20000, 0.01); time_limit_sec=5)
+solve_clp(10, RandomLP(10000, 20000, 0.01); time_limit_sec=5)

--- a/src/MOI_wrapper/MOI_wrapper.jl
+++ b/src/MOI_wrapper/MOI_wrapper.jl
@@ -233,8 +233,10 @@ function _extract_row_data(src, mapping, lb, ub, I, J, V, ::Type{S}) where S
     add_sizehint!(lb, length(list))
     add_sizehint!(ub, length(list))
     n_terms = 0
-    for c_index in list
+    fs = Array{MOI.ScalarAffineFunction{Float64}}(undef, length(list))
+    for (i,c_index) in enumerate(list)
         f = MOI.get(src, MOI.ConstraintFunction(), c_index)
+        fs[i] = f
         l, u = _bounds(MOI.get(src, MOI.ConstraintSet(), c_index))
         push!(lb, l - f.constant)
         push!(ub, u - f.constant)
@@ -243,8 +245,8 @@ function _extract_row_data(src, mapping, lb, ub, I, J, V, ::Type{S}) where S
     add_sizehint!(I, n_terms)
     add_sizehint!(J, n_terms)
     add_sizehint!(V, n_terms)
-    for c_index in list
-        f = MOI.get(src, MOI.ConstraintFunction(), c_index)
+    for (i,c_index) in enumerate(list)
+        f = fs[i]#MOI.get(src, MOI.ConstraintFunction(), c_index)
         for term in f.terms
             push!(I, row)
             push!(J, Cint(mapping.varmap[term.variable_index].value))

--- a/src/MOI_wrapper/MOI_wrapper.jl
+++ b/src/MOI_wrapper/MOI_wrapper.jl
@@ -185,7 +185,7 @@ _add_bounds(lb, ::Vector{Float64}, i, s::MOI.GreaterThan{Float64}) = lb[i] = s.l
 _add_bounds(lb, ub, i, s::MOI.EqualTo{Float64}) = lb[i], ub[i] = s.value, s.value
 _add_bounds(lb, ub, i, s::MOI.Interval{Float64}) = lb[i], ub[i] = s.lower, s.upper
 
-function _extract_bound_data(src, mapping, lb, ub, S)
+function _extract_bound_data(src, mapping, lb, ub, ::Type{S}) where S
     for con_index in MOI.get(
         src, MOI.ListOfConstraintIndices{MOI.SingleVariable, S}()
     )
@@ -220,15 +220,31 @@ _bounds(s::MOI.LessThan{Float64}) = (-Inf, s.upper)
 _bounds(s::MOI.EqualTo{Float64}) = (s.value, s.value)
 _bounds(s::MOI.Interval{Float64}) = (s.lower, s.upper)
 
-function _extract_row_data(src, mapping, lb, ub, I, J, V, S)
+function add_sizehint!(vec, n)
+    len = length(vec)
+    return sizehint!(vec, len + n)
+end
+
+function _extract_row_data(src, mapping, lb, ub, I, J, V, ::Type{S}) where S
     row = length(I) == 0 ? 1 : I[end] + 1
-    for c_index in MOI.get(
+    list = MOI.get(
         src, MOI.ListOfConstraintIndices{MOI.ScalarAffineFunction{Float64}, S}()
     )
+    add_sizehint!(lb, length(list))
+    add_sizehint!(ub, length(list))
+    n_terms = 0
+    for c_index in list
         f = MOI.get(src, MOI.ConstraintFunction(), c_index)
         l, u = _bounds(MOI.get(src, MOI.ConstraintSet(), c_index))
         push!(lb, l - f.constant)
         push!(ub, u - f.constant)
+        n_terms += length(f.terms)
+    end
+    add_sizehint!(I, n_terms)
+    add_sizehint!(J, n_terms)
+    add_sizehint!(V, n_terms)
+    for c_index in list
+        f = MOI.get(src, MOI.ConstraintFunction(), c_index)
         for term in f.terms
             push!(I, row)
             push!(J, Cint(mapping.varmap[term.variable_index].value))
@@ -242,12 +258,7 @@ function _extract_row_data(src, mapping, lb, ub, I, J, V, S)
     return
 end
 
-function MOI.copy_to(
-    dest::Optimizer,
-    src::MOI.ModelLike;
-    copy_names::Bool = false
-)
-    @assert MOI.is_empty(dest)
+function test_data(src, dest)
     for (F, S) in MOI.get(src, MOI.ListOfConstraints())
         if !MOI.supports_constraint(dest, F, S)
             throw(MOI.UnsupportedConstraint{F, S}("Clp.Optimizer does not support constraints of type $F-in-$S."))
@@ -257,19 +268,30 @@ function MOI.copy_to(
     if !MOI.supports(dest, MOI.ObjectiveFunction{fobj_type}())
         throw(MOI.UnsupportedAttribute(MOI.ObjectiveFunction(fobj_type)))
     end
+end
+
+function MOI.copy_to(
+    dest::Optimizer,
+    src::MOI.ModelLike;
+    copy_names::Bool = false
+)
+    @assert MOI.is_empty(dest)
+    test_data(src, dest)
+
     mapping = MOI.Utilities.IndexMap()
     N, c = _copy_to_columns(dest, src, mapping)
     cl, cu = fill(-Inf, N), fill(Inf, N)
     rl, ru, I, J, V = Float64[], Float64[], Cint[], Cint[], Float64[]
-    for S in (
-        MOI.GreaterThan{Float64},
-        MOI.LessThan{Float64},
-        MOI.EqualTo{Float64},
-        MOI.Interval{Float64},
-    )
-        _extract_bound_data(src, mapping, cl, cu, S)
-        _extract_row_data(src, mapping, rl, ru, I, J, V, S)
-    end
+
+    _extract_bound_data(src, mapping, cl, cu, MOI.GreaterThan{Float64})
+    _extract_row_data(src, mapping, rl, ru, I, J, V, MOI.GreaterThan{Float64})
+    _extract_bound_data(src, mapping, cl, cu, MOI.LessThan{Float64})
+    _extract_row_data(src, mapping, rl, ru, I, J, V, MOI.LessThan{Float64})
+    _extract_bound_data(src, mapping, cl, cu, MOI.EqualTo{Float64})
+    _extract_row_data(src, mapping, rl, ru, I, J, V, MOI.EqualTo{Float64})
+    _extract_bound_data(src, mapping, cl, cu, MOI.Interval{Float64})
+    _extract_row_data(src, mapping, rl, ru, I, J, V, MOI.Interval{Float64})
+
     M = Cint(length(rl))
     A = SparseArrays.sparse(I, J, V, M, N)
     Clp_loadProblem(


### PR DESCRIPTION
I added that benchmark file: bench/runbench.jl

There are major speedups with this little changes

Current master:

```
 ──────────────────────────────────────────────────────────────────
                           Time                   Allocations
                   ──────────────────────   ───────────────────────
 Tot / % measured:      85.9s / 100%            25.6GiB / 100%

 Section   ncalls     time   %tot     avg     alloc   %tot      avg
 ──────────────────────────────────────────────────────────────────
 c + s         10    17.3s  20.2%   1.73s   4.85GiB  19.0%   497MiB
   opt         10    9.82s  11.4%   982ms     0.00B  0.00%    0.00B
   copy        10    7.14s  8.32%   714ms   4.19GiB  16.4%   429MiB
   build       10    370ms  0.43%  37.0ms    676MiB  2.58%  67.6MiB
 bcs           10    17.2s  20.0%   1.72s   4.92GiB  19.2%   504MiB
   opt         10    16.8s  19.6%   1.68s   4.26GiB  16.6%   436MiB
   build       10    352ms  0.41%  35.2ms    677MiB  2.58%  67.7MiB
 cs            10    17.2s  20.0%   1.72s   4.92GiB  19.2%   504MiB
   opt         10    16.8s  19.6%   1.68s   4.26GiB  16.6%   436MiB
   build       10    370ms  0.43%  37.0ms    677MiB  2.58%  67.7MiB
 bcs + v       10    17.1s  19.9%   1.71s   5.45GiB  21.3%   558MiB
   opt         10    16.3s  19.0%   1.63s   4.26GiB  16.6%   436MiB
   build       10    719ms  0.84%  71.9ms   1.19GiB  4.66%   122MiB
 bc + s        10    16.4s  19.1%   1.64s   4.86GiB  19.0%   497MiB
   opt         10    8.91s  10.4%   891ms     0.00B  0.00%    0.00B
   copy        10    7.07s  8.24%   707ms   4.20GiB  16.4%   430MiB
   build       10    413ms  0.48%  41.3ms    676MiB  2.58%  67.6MiB
 data          10    677ms  0.79%  67.7ms    617MiB  2.35%  61.7MiB
 ──────────────────────────────────────────────────────────────────
```


After this PR:

```
 ──────────────────────────────────────────────────────────────────
                           Time                   Allocations
                   ──────────────────────   ───────────────────────
 Tot / % measured:      52.8s / 100%            8.91GiB / 100%

 Section   ncalls     time   %tot     avg     alloc   %tot      avg
 ──────────────────────────────────────────────────────────────────
 bcs + v       10    10.9s  20.7%   1.09s   2.11GiB  23.7%   216MiB
   opt         10    10.2s  19.3%   1.02s    938MiB  10.3%  93.8MiB
   build       10    744ms  1.41%  74.4ms   1.19GiB  13.4%   122MiB
 bcs           10    10.6s  20.0%   1.06s   1.58GiB  17.7%   161MiB
   opt         10    10.1s  19.1%   1.01s    938MiB  10.3%  93.8MiB
   build       10    454ms  0.86%  45.4ms    677MiB  7.43%  67.7MiB
 bc + s        10    10.3s  19.4%   1.03s   1.53GiB  17.1%   156MiB
   opt         10    8.31s  15.7%   831ms     0.00B  0.00%    0.00B
   copy        10    1.72s  3.25%   172ms    887MiB  9.73%  88.7MiB
   build       10    212ms  0.40%  21.2ms    676MiB  7.41%  67.6MiB
 cs            10    10.1s  19.2%   1.01s   1.58GiB  17.7%   161MiB
   opt         10    9.80s  18.6%   980ms    938MiB  10.3%  93.8MiB
   build       10    332ms  0.63%  33.2ms    677MiB  7.43%  67.7MiB
 c + s         10    10.1s  19.1%   1.01s   1.51GiB  17.0%   155MiB
   opt         10    8.15s  15.4%   815ms     0.00B  0.00%    0.00B
   copy        10    1.62s  3.07%   162ms    874MiB  9.58%  87.4MiB
   build       10    325ms  0.62%  32.5ms    676MiB  7.41%  67.6MiB
 data          10    789ms  1.49%  78.9ms    617MiB  6.76%  61.7MiB
 ──────────────────────────────────────────────────────────────────
```

cc @odow @mlubin @blegat 